### PR TITLE
Stop installing ack

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jldugger@gmail.com'
 license 'GPL-2.0'
 description 'Installs/Configures workstation'
 long_description 'Installs/Configures workstation'
-version '0.2.8'
+version '0.2.9'
 
 chef_version '>= 12.5' if respond_to?(:chef_version)
 supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,6 @@ node['desktop']['repos'].each do |repo, key|
 end
 
 %w[
-  ack-grep
   awscli
   chromium-browser
   csvtool


### PR DESCRIPTION
ack doesn't appear to be in the ubuntu reops, and this causes chef run failures. remove it!